### PR TITLE
Alteré los archivos necesarios para cambiar de decir 'WhatsApp' a decir "e-mail"

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,7 @@
             </div>
 
             <div class="row header center">
-                <div class="dark-grey"><span data-i18n="or-contacting-us">or contacting us via</span> <a class="black" href="https://wa.me/59996830289"
-                        target="_blank" data-i18n="whatsapp">WhatsApp</a></div>
+                <div class="dark-grey"><span data-i18n="or-contacting-us">or contacting us via</span> <a class="black" href="mailto:contact@icebergmultiservices.com" target="_blank" data-i18n="e-mail">e-mail</a></div>
             </div>
         </div>
     </section>
@@ -190,7 +189,7 @@
                 </div>
 
                 <p class="text white"><span data-i18n="schedule-your-service">1. Schedule your appointment with the service you'd like to receive using our app
-                    or</span> <a class="white" href="https://wa.me/59996830289" target="_blank" data-i18n="contacting-us">contacting
+                    or</span> <a class="white" href="mailto:contact@icebergmultiservices.com" target="_blank" data-i18n="contacting-us">contacting
                         us</a>.<br /><br /><span class="material-symbols-outlined white">arrow_right_alt</span></p>
             </div>
 
@@ -361,9 +360,9 @@
             <a class="white" href="https://icebergmultiservices.com/" data-i18n="company-site">icebergmultiservices.com</a>
 
             <div class="linked-icons">
-                <a href="https://wa.me/59996830289" target="_blank">
-                    <img src="/img/index/whatsapp-logo.png" alt="WhatsApp Logo">
-                </a>
+                <!--<a href="https://wa.me/59996830289" target="_blank">-->
+                    <!--<img src="/img/index/whatsapp-logo.png" alt="WhatsApp Logo">-->
+                <!--</a>-->
 
                 <a href="https://www.instagram.com/icebergmultiservices/" target="_blank">
                     <img src="/img/index/instagram-logo.png" alt="Instagram Logo">

--- a/js/i18n/eng.json
+++ b/js/i18n/eng.json
@@ -18,7 +18,7 @@
     "ios-app": "iOS App",
     "android-app": "Android App",
     "or-contacting-us": "or contacting us via",
-    "whatsapp": "WhatsApp",
+    "e-mail": "e-mail",
     "what-we-do": "What We Do",
     "we-sell-and-install": "We sell and install the best Air Conditioners from our providers to you!",
     "we-diagnose-and-repair": "We diagnose and repair your Air Conditioner.",

--- a/js/i18n/nld.json
+++ b/js/i18n/nld.json
@@ -18,7 +18,7 @@
     "ios-app": "iOS App",
     "android-app": "Android App",
     "or-contacting-us": "of neem contact met ons op via",
-    "whatsapp": "WhatsApp",
+    "e-mail": "e-mail",
     "what-we-do": "Wat We Doen",
     "we-sell-and-install": "Wij verkopen en installeren de beste airconditioners van onze leveranciers aan jou!",
     "we-diagnose-and-repair": "Wij diagnosticeren en repareren uw airco.",

--- a/js/i18n/pap.json
+++ b/js/i18n/pap.json
@@ -19,7 +19,7 @@
     "ios-app": "iOS App",
     "android-app": "Android App",
     "or-contacting-us": "òf tuma kontakto serka nos via",
-    "whatsapp": "WhatsApp",
+    "e-mail": "e-mail",
     "what-we-do": "lo ke nos ta hasi",
     "we-sell-and-install": "Bende i instalá e miho air conditioning di nos provedornan pa bo!",
     "we-diagnose-and-repair": "Nos ta diagnostiká i drecha bo aire conditions.",

--- a/js/i18n/spa.json
+++ b/js/i18n/spa.json
@@ -18,7 +18,7 @@
     "ios-app": "App de iOS",
     "android-app": "App de Android",
     "or-contacting-us": "O contactando con nosotros a través de",
-    "whatsapp": "WhatsApp",
+    "e-mail": "correo electrónico",
     "what-we-do": "Lo Que Hacemos",
     "we-sell-and-install": "¡Vendemos e instalamos los mejores Aires Acondicionados de nuestros proveedores para usted!",
     "we-diagnose-and-repair": "Diagnosticamos y reparamos su Aire Acondicionado.",


### PR DESCRIPTION
Hola, seguí las instrucciones del [issue#1](https://github.com/Iceberg-Multiservices/Iceberg-Multiservices.github.io/issues/1) para cambiar los enlaces que dirigían a un chat de WhatsApp, a otros que redirigen al correo electrónico de la compañía.

También añadí las entradas para cada idioma porque no encontré en ninguna parte las palabras que se usan para el correo electrónico, por último, quité el botón verde de WhatsApp que se encontraba en el pie de la página.

Por favor, déjame saber si se necesita algún cambio para implementar los cambios.